### PR TITLE
fix: Concat should receive lists as arguments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2101,10 +2101,10 @@ module "karpenter" {
   postrender = try(var.karpenter.postrender, [])
   set = concat(
     [for s in local.karpenter_set : s if s.value != null],
-    {
+    [{
       name                  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
       value_is_iam_role_arn = true
-    },
+    }],
     try(var.karpenter.set, [])
   )
   set_sensitive = try(var.karpenter.set_sensitive, [])


### PR DESCRIPTION
### What does this PR do?

Fix concat arguments to make the second argument a list of objects.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

```bash
Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Error: Invalid function argument
│
│   on .terraform/modules/eks_blueprints_addons/main.tf line 3083, in module "karpenter":
│ 3081:   set = concat(
│ 3082:     [for s in local.karpenter_set : s if s.value != null],
│ 3083:     {
│ 3084:       name                  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
│ 3085:       value_is_iam_role_arn = true
│ 3086:     },
│ 3087:     try(var.karpenter.set, [])
│ 3088:   )
│     ├────────────────
│     │ while calling concat(seqs...)
│
│ Invalid value for "seqs" parameter: all arguments must be lists or tuples; got object.

```

### Test Results

<!-- Please provide supporting evidence and steps taking to test and validation this change -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->
